### PR TITLE
Check for executables

### DIFF
--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -23,8 +23,8 @@ type DCOSChecker interface {
 }
 
 // RunCheck is a helper function to run the check and emit the result.
-func RunCheck(check DCOSChecker) {
-	output, retCode, err := check.Run(nil, DCOSConfig)
+func RunCheck(ctx context.Context, check DCOSChecker) {
+	output, retCode, err := check.Run(ctx, DCOSConfig)
 	if err != nil {
 		logrus.Fatalf("Error executing %s: %s", check.ID(), err)
 	}
@@ -37,8 +37,16 @@ func RunCheck(check DCOSChecker) {
 }
 
 // NewComponentCheck returns an initialized instance of *ComponentCheck.
-func NewComponentCheck(name string) *ComponentCheck {
+func NewComponentCheck(name string) DCOSChecker {
 	return &ComponentCheck{
 		Name: name,
+	}
+}
+
+// NewExecutableCheck returns an intiialized instance of *ExecutableCheck
+func NewExecutableCheck(name string, args []string) DCOSChecker {
+	return &ExecutableCheck{
+		Name: name,
+		Args: args,
 	}
 }

--- a/cmd/components_check.go
+++ b/cmd/components_check.go
@@ -64,7 +64,7 @@ and validating the health field:
 }
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		RunCheck(NewComponentCheck("DC/OS components health check"))
+		RunCheck(context.TODO(), NewComponentCheck("DC/OS components health check"))
 	},
 }
 

--- a/cmd/executable_check.go
+++ b/cmd/executable_check.go
@@ -1,0 +1,97 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/dcos/dcos-go/exec"
+	"github.com/spf13/cobra"
+)
+
+var validExecutables = map[string]bool{
+	"curl":  true,
+	"wget":  true,
+	"tar":   true,
+	"git":   true,
+	"xz":    true,
+	"unzip": true,
+}
+
+// executableCmd represents the executable command
+var executableCmd = &cobra.Command{
+	Use:   "executable",
+	Short: "Check for executable/executables required to install DC/OS",
+	Long: `Check for existence of the following executable: 
+curl
+wget
+tar
+git
+xz
+unzip
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		RunCheck(context.TODO(), NewExecutableCheck("DC/OS verify existence of executables", args))
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(executableCmd)
+}
+
+// ExecutableCheck validates we have the required executable to install/run DC/OS
+type ExecutableCheck struct {
+	Name string
+	Args []string
+}
+
+// ID returns a unique check identifier.
+func (c *ExecutableCheck) ID() string {
+	return c.Name
+}
+
+// Run the binary check
+func (c *ExecutableCheck) Run(ctx context.Context, cfg *CLIConfigFlags) (string, int, error) {
+	err := c.executableExists(ctx, cfg)
+	if err != nil {
+		return "", statusFailure, err
+	}
+	return "", statusOK, nil
+}
+
+func (c *ExecutableCheck) executableExists(ctx context.Context, cfg *CLIConfigFlags) error {
+	var args = c.Args
+
+	if len(args) == 0 {
+		return fmt.Errorf("No executable to check")
+	}
+
+	if len(args) > 1 {
+		return fmt.Errorf("Only one executable allowed at a time")
+	}
+
+	if !validExecutables[args[0]] {
+		var keys []string
+		for key := range validExecutables {
+			keys = append(keys, key)
+		}
+		return fmt.Errorf("Choose from valid list of executables %v", keys)
+	}
+
+	if _, _, _, err := exec.Output(ctx, args[0]); err != nil {
+		return fmt.Errorf("%s not installed", args[0])
+	}
+	return nil
+}

--- a/cmd/executable_test.go
+++ b/cmd/executable_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "testing"
+import "context"
+
+// TestExecutableExists validates binary exists
+func TestExecutableExists(t *testing.T) {
+	// negative test case so it passes on mac
+	c := &ExecutableCheck{"Test", []string{"curling"}}
+	mockCLICfg := &CLIConfigFlags{
+		NodeIPStr: "127.0.0.1",
+		Role:      "master",
+		ForceTLS:  false,
+	}
+
+	err := c.executableExists(context.Background(), mockCLICfg)
+	if err == nil {
+		t.Fatalf("Should have returned an error")
+	}
+}


### PR DESCRIPTION
amita@amita-desktop:~/Development/go-projects/src/github.com/dcos/dcos-checks$ ./dcos-checks 
DC/OS checks provides an easy interface to check the DC/OS components health

The checks could be executed against a signle node, or a whole cluster.

Usage:
  checks [command]

Available Commands:
  components  Check DC/OS components
  executable  Check for executable/executables required to install DC/OS


amita@amita-desktop:/Development/go-projects/src/github.com/dcos/dcos-checks$ ./dcos-checks executable
FATA Error executing DC/OS verify existence of executables: No executable to check 
amita@amita-desktop:/Development/go-projects/src/github.com/dcos/dcos-checks$ ./dcos-checks executable curl
amita@amita-desktop:/Development/go-projects/src/github.com/dcos/dcos-checks$ ./dcos-checks executable clew
FATA Error executing DC/OS verify existence of executables: Choose from valid list of executables 
amita@amita-desktop:/Development/go-projects/src/github.com/dcos/dcos-checks$ 