### PR TITLE
Mesos metrics snapshot check

### DIFF
--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -35,25 +35,3 @@ func RunCheck(ctx context.Context, check DCOSChecker) {
 
 	os.Exit(retCode)
 }
-
-// NewComponentCheck returns an initialized instance of *ComponentCheck.
-func NewComponentCheck(name string) DCOSChecker {
-	return &ComponentCheck{
-		Name: name,
-	}
-}
-
-// NewExecutableCheck returns an intialized instance of *ExecutableCheck
-func NewExecutableCheck(name string, args []string) DCOSChecker {
-	return &ExecutableCheck{
-		Name: name,
-		Args: args,
-	}
-}
-
-// NewZkQuorumCheck returns an initialized instance of *ComponentCheck.
-func NewZkQuorumCheck(name string) DCOSChecker {
-	return &ZkQuorumCheck{
-		Name: name,
-	}
-}

--- a/cmd/components_check.go
+++ b/cmd/components_check.go
@@ -51,6 +51,13 @@ var (
 	healthURLPrefix string
 )
 
+// NewComponentCheck returns an initialized instance of *ComponentCheck.
+func NewComponentCheck(name string) DCOSChecker {
+	return &ComponentCheck{
+		Name: name,
+	}
+}
+
 // componentsCmd represents the systemd health check
 var componentsCmd = &cobra.Command{
 	Use:   "components",

--- a/cmd/executable_check.go
+++ b/cmd/executable_check.go
@@ -30,6 +30,14 @@ var validExecutables = map[string]bool{
 	"unzip": true,
 }
 
+// NewExecutableCheck returns an intialized instance of *ExecutableCheck
+func NewExecutableCheck(name string, args []string) DCOSChecker {
+	return &ExecutableCheck{
+		Name: name,
+		Args: args,
+	}
+}
+
 // executableCmd represents the executable command
 var executableCmd = &cobra.Command{
 	Use:   "executable",

--- a/cmd/mesos_metrics_check.go
+++ b/cmd/mesos_metrics_check.go
@@ -1,0 +1,157 @@
+// Copyright © 2017 Mesosphere Inc. <http://mesosphere.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/dcos/dcos-checks/client"
+	"github.com/dcos/dcos-go/dcos"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const (
+	mesosMasterHTTPPort = 5050
+	mesosAgentHTTPPort  = 5051
+	nodeRecovered       = 1.0
+)
+
+// mesosMetricsCmd represents the mesos-metrics command
+var mesosMetricsCmd = &cobra.Command{
+	Use:   "mesos-metrics",
+	Short: "Get the mesos metrics snapshot",
+	Long:  `Metrics snapshot lets us know if the mesos rep logs are synchronized`,
+	Run: func(cmd *cobra.Command, args []string) {
+		RunCheck(context.TODO(), NewMesosMetricsCheck("DC/OS metrics snapshot check"))
+	},
+}
+
+// NewMesosMetricsCheck returns an initialized instance of *MesosMetricsCheck.
+func NewMesosMetricsCheck(name string) DCOSChecker {
+	check := &MesosMetricsCheck{Name: name}
+	check.urlFunc = check.getURL
+	return check
+}
+
+// MesosMetricsCheck checks if mesos replogs are synchronized by checking
+// the value of /metrics/snapshot
+type MesosMetricsCheck struct {
+	Name    string
+	urlFunc func(*http.Client, *CLIConfigFlags) (*url.URL, error)
+}
+
+// ID returns a unique check identifier.
+func (mm *MesosMetricsCheck) ID() string {
+	return mm.Name
+}
+
+func init() {
+	RootCmd.AddCommand(mesosMetricsCmd)
+}
+
+// Run invokes a check and return error output, exit code and error.
+func (mm *MesosMetricsCheck) Run(ctx context.Context, cfg *CLIConfigFlags) (string, int, error) {
+	type masterResponse struct {
+		Recovered float64 `json:"registrar/log/recovered"`
+	}
+
+	type agentResponse struct {
+		Recovered float64 `json:"slave/registered"`
+		Output    string
+	}
+
+	httpClient, err := client.NewClient(cfg.IAMConfig, cfg.CACert)
+	if err != nil {
+		return "", statusUnknown, errors.Wrap(err, "Unable to create HTTP client")
+	}
+
+	url, err := mm.urlFunc(httpClient, cfg)
+	if err != nil {
+		return "", statusFailure, errors.Wrap(err, "Unable to get url")
+	}
+
+	logrus.Debugf("GET %s", url)
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return "", statusUnknown, errors.Wrap(err, "Unable to create a new HTTP request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", statusUnknown, errors.Wrapf(err, "Unable to execute GET %s", url)
+	}
+	defer resp.Body.Close()
+
+	if cfg.Role == dcos.RoleMaster {
+		var jsonResponse masterResponse
+		if err := json.NewDecoder(resp.Body).Decode(&jsonResponse); err != nil {
+			return "", statusUnknown, errors.Wrap(err, "Unable to unmarshal response")
+		}
+
+		if jsonResponse.Recovered == nodeRecovered {
+			return "", statusOK, nil
+		}
+	} else {
+		var jsonResponse agentResponse
+		if err := json.NewDecoder(resp.Body).Decode(&jsonResponse); err != nil {
+			return "", statusUnknown, errors.Wrap(err, "Unable to unmarshal response")
+		}
+
+		if jsonResponse.Recovered == nodeRecovered {
+			return "", statusOK, nil
+		}
+		return "", statusFailure, errors.New("Mesos replog not synchronized")
+	}
+
+	return "", statusUnknown, errors.New("Unable to run the check")
+}
+
+func (mm *MesosMetricsCheck) getURL(httpClient *http.Client, cfg *CLIConfigFlags) (*url.URL, error) {
+
+	portsMap := map[string]int{
+		dcos.RoleMaster:      mesosMasterHTTPPort,
+		dcos.RoleAgent:       mesosAgentHTTPPort,
+		dcos.RoleAgentPublic: mesosAgentHTTPPort,
+	}
+
+	port, ok := portsMap[cfg.Role]
+	if !ok {
+		return nil, errors.Errorf("invalid role %s", cfg.Role)
+	}
+
+	scheme := httpScheme
+	if cfg.ForceTLS {
+		scheme = httpsScheme
+	}
+
+	ip, err := cfg.IP(httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(ip.String(), strconv.Itoa(port)),
+		Path:   "/metrics/snapshot",
+	}, nil
+}

--- a/cmd/mesos_metrics_test.go
+++ b/cmd/mesos_metrics_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// TestMesosMetricsCheckUrl verifies we get the right url
+func TestMesosMetricsCheckUrl(t *testing.T) {
+	test := &MesosMetricsCheck{
+		Name: "TEST",
+	}
+
+	for _, testCase := range []struct {
+		role     string
+		forceTLS bool
+		expected string
+	}{
+		{
+			role:     "master",
+			forceTLS: false,
+			expected: "http://127.0.0.1:5050/metrics/snapshot",
+		},
+		{
+			role:     "agent_public",
+			forceTLS: false,
+			expected: "http://127.0.0.1:5051/metrics/snapshot",
+		},
+		{
+			role:     "agent",
+			forceTLS: true,
+			expected: "https://127.0.0.1:5051/metrics/snapshot",
+		},
+	} {
+		mockCLICfg := &CLIConfigFlags{
+			NodeIPStr: "127.0.0.1",
+			Role:      testCase.role,
+			ForceTLS:  testCase.forceTLS,
+		}
+
+		url, err := test.getURL(nil, mockCLICfg)
+		if err != nil {
+			t.Fatalf("Error running getURL: %s", err)
+		}
+
+		if url.String() != testCase.expected {
+			t.Fatalf("Expect %s. Got %s", testCase.expected, url)
+		}
+	}
+}
+
+// TestMesosMetricsCheckRun checks run
+func TestMesosMetricsCheckRun(t *testing.T) {
+	for _, testCase := range []struct {
+		role      string
+		forceTLS  bool
+		status    int
+		response  string
+		expStatus int
+	}{
+		{
+			role:      "master",
+			forceTLS:  false,
+			status:    http.StatusOK,
+			response:  `{"slave\/tasks_finished":0.0,"slave\/cpus_total":4.0,"slave\/executors_preempted":0.0,"slave\/registered":1.0,"registrar\/log\/recovered": 1.0}`,
+			expStatus: statusOK,
+		},
+		{
+			role:      "agent",
+			forceTLS:  false,
+			status:    http.StatusOK,
+			response:  `{"slave\/tasks_finished":0.0,"slave\/cpus_total":4.0,"slave\/executors_preempted":0.0,"slave\/registered":1.0,"registrar\/log\/recovered": 1.0}`,
+			expStatus: statusOK,
+		},
+		{
+			role:      "agent",
+			forceTLS:  false,
+			status:    http.StatusOK,
+			response:  `{"slave\/tasks_finished":0.0,"slave\/cpus_total":4.0,"slave\/executors_preempted":0.0,"slave\/registered":0.0,"registrar\/log\/recovered": 1.0}`,
+			expStatus: statusFailure,
+		},
+	} {
+		mockCLICfg := &CLIConfigFlags{
+			NodeIPStr: "127.0.0.1",
+			Role:      testCase.role,
+			ForceTLS:  testCase.forceTLS,
+		}
+
+		masterHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(testCase.status)
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, testCase.response)
+		})
+
+		masterServer := httptest.NewServer(masterHandler)
+		defer masterServer.Close()
+
+		test := &MesosMetricsCheck{
+			Name: "TEST",
+			urlFunc: func(client *http.Client, cfg *CLIConfigFlags) (*url.URL, error) {
+				return url.Parse(masterServer.URL)
+			},
+		}
+		_, status, err := test.Run(context.TODO(), mockCLICfg)
+		if status != testCase.expStatus {
+			t.Fatalf("Status %d not as expected status %d %s", status, testCase.expStatus, err)
+		}
+	}
+}

--- a/cmd/zk_quorum_check.go
+++ b/cmd/zk_quorum_check.go
@@ -31,6 +31,13 @@ import (
 
 const zkResponseServing = 3
 
+// NewZkQuorumCheck returns an initialized instance of *ComponentCheck.
+func NewZkQuorumCheck(name string) DCOSChecker {
+	return &ZkQuorumCheck{
+		Name: name,
+	}
+}
+
 // zkQuorumCmd represents the zk-quorum command
 var zkQuorumCmd = &cobra.Command{
 	Use:   "zk-quorum",

--- a/cmd/zk_quorum_test.go
+++ b/cmd/zk_quorum_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import "testing"
 
-// TestZookeeperQuorumCheckGetHealthURL validates that parameters Role and ForceTLS
+// TestZookeeperQuorumCheckGetURL validates that parameters Role and ForceTLS
 // return the expected URL based on adminrouter configuration.
-func TestZookeeperQuorumCheckGetHealthURL(t *testing.T) {
+func TestZookeeperQuorumCheckGetURL(t *testing.T) {
 	zk := &ZkQuorumCheck{
 		Name: "TEST",
 	}


### PR DESCRIPTION
This check verifies the following:
1. Master mesos replogs are synchronized, this is used currently to verify if a master has been upgraded successfully
2. Agent node has rejoined the cluster, used currently to test if upgrade of a node is successful. 

https://jira.mesosphere.com/browse/DCOS-15422 
https://jira.mesosphere.com/browse/DCOS-15424

amita@amita-desktop:~/Development/go-projects/src/github.com/dcos/dcos-checks$ ./dcos-checks mesos-metrics
FATA[0000] Error executing DC/OS metrics snapshot check: invalid role  

amita@amita-desktop:/Development/go-projects/src/github.com/dcos/dcos-checks$ ./dcos-checks mesos-metrics --role master
FATA[0000] Error executing DC/OS metrics snapshot check: stat /opt/mesosphere/bin/detect_ip: no such file or directory 
amita@amita-desktop:/Development/go-projects/src/github.com/dcos/dcos-checks$ ./dcos-checks mesos-metrics --role agent
FATA[0000] Error executing DC/OS metrics snapshot check: stat /opt/mesosphere/bin/detect_ip: no such file or directory  