### PR TITLE
Cluster check for dc/os version

### DIFF
--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -16,6 +16,24 @@ const (
 
 	// exhibitor admin router port
 	exhibitorPort = 8181
+
+	// master node has a 3dt instance running on TCP port 1050.
+	// ee version has 3dt running via unix socket on both master and agent nodes,
+	// depending on security option. Ports 80 or 443 are using accordingly.
+	dcosDiagnosticsMasterHTTPPort = 1050
+	adminrouterMasterHTTPSPort    = 443
+
+	// agent node runs 3dt via unix socket and is available though the agent
+	// adminrouter HTTP TCP port 61001 or HTTPS 61002.
+	adminrouterAgentHTTPPort  = 61001
+	adminrouterAgentHTTPSPort = 61002
+
+	mesosMasterHTTPPort = 5050
+	mesosAgentHTTPPort  = 5051
+	mesosDNSPort        = 8123
+
+	httpScheme  = "http"
+	httpsScheme = "https"
 )
 
 // DCOSChecker defines an interface for a generic DC/OS check.

--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -3,8 +3,15 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 
+	"github.com/dcos/dcos-checks/client"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -43,6 +50,13 @@ type DCOSChecker interface {
 	Run(context.Context, *CLIConfigFlags) (string, int, error)
 }
 
+// URLFields is used to construct the url
+type URLFields struct {
+	host string
+	port int
+	path string
+}
+
 // RunCheck is a helper function to run the check and emit the result.
 func RunCheck(ctx context.Context, check DCOSChecker) {
 	output, retCode, err := check.Run(ctx, DCOSConfig)
@@ -55,4 +69,56 @@ func RunCheck(ctx context.Context, check DCOSChecker) {
 	}
 
 	os.Exit(retCode)
+}
+
+// HTTPRequest verifies the results of the request
+func HTTPRequest(cfg *CLIConfigFlags, urlOptions URLFields) ([]byte, error) {
+	httpClient, err := client.NewClient(cfg.IAMConfig, cfg.CACert)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create HTTP client")
+	}
+
+	url, err := getURL(httpClient, cfg, urlOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("GET %s", url)
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create a new HTTP request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to execute GET %s", url)
+	}
+
+	responseData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read response body")
+	}
+	defer resp.Body.Close()
+
+	return responseData, nil
+}
+
+func getURL(httpClient *http.Client, cfg *CLIConfigFlags, urlOptions URLFields) (*url.URL, error) {
+	scheme := httpScheme
+	if cfg.ForceTLS {
+		scheme = httpsScheme
+	}
+
+	if urlOptions.port == 0 {
+		return &url.URL{
+			Scheme: scheme,
+			Host:   urlOptions.host,
+			Path:   urlOptions.path,
+		}, nil
+	}
+	return &url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(urlOptions.host, strconv.Itoa(urlOptions.port)),
+		Path:   urlOptions.path,
+	}, nil
 }

--- a/cmd/components_check.go
+++ b/cmd/components_check.go
@@ -31,22 +31,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	// master node has a 3dt instance running on TCP port 1050.
-	// ee version has 3dt running via unix socket on both master and agent nodes,
-	// depending on security option. Ports 80 or 443 are using accordingly.
-	dcosDiagnosticsMasterHTTPPort = 1050
-	adminrouterMasterHTTPSPort    = 443
-
-	// agent node runs 3dt via unix socket and is available though the agent
-	// adminrouter HTTP TCP port 61001 or HTTPS 61002.
-	adminrouterAgentHTTPPort  = 61001
-	adminrouterAgentHTTPSPort = 61002
-
-	httpScheme  = "http"
-	httpsScheme = "https"
-)
-
 var (
 	healthURLPrefix string
 )

--- a/cmd/mesos_metrics_check.go
+++ b/cmd/mesos_metrics_check.go
@@ -30,9 +30,7 @@ import (
 )
 
 const (
-	mesosMasterHTTPPort = 5050
-	mesosAgentHTTPPort  = 5051
-	nodeRecovered       = 1.0
+	nodeRecovered = 1.0
 )
 
 // mesosMetricsCmd represents the mesos-metrics command

--- a/cmd/version_check.go
+++ b/cmd/version_check.go
@@ -1,0 +1,269 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/dcos/dcos-checks/client"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewVersionCheck returns an initialized instance of *ComponentCheck.
+func NewVersionCheck(name string) DCOSChecker {
+	check := &VersionCheck{Name: name}
+	check.ClusterLeader = "leader.mesos"
+	return check
+}
+
+// MasterListResponse response for leader.mesos/master.mesos
+type MasterListResponse []struct {
+	Host string `json:"host"`
+	IP   string `json:"ip"`
+}
+
+// AgentListResponse response for /slaves
+type AgentListResponse struct {
+	Slaves []struct {
+		ID         string `json:"id"`
+		Hostname   string `json:"hostname"`
+		Port       int    `json:"port"`
+		Attributes struct {
+			PublicIP string `json:"public_ip"`
+		} `json:"attributes"`
+	} `json:"slaves"`
+	RecoveredSlaves []interface{} `json:"recovered_slaves"`
+}
+
+// VersionResponse responses /dcos-metadata/dcos-version.json
+type VersionResponse struct {
+	Version         string `json:"version"`
+	DcosImageCommit string `json:"dcos-image-commit"`
+	BootstrapID     string `json:"bootstrap-id"`
+}
+
+// URLFields is used to construct the url
+type URLFields struct {
+	host string
+	port int
+	path string
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Check DC/OS version of the cluster",
+	Long: `Check dc/os version on each node in the cluster.
+At any point there shouldnt be more than 2 versions that exist.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		RunCheck(context.TODO(), NewVersionCheck("DC/OS version check"))
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+
+// VersionCheck struct
+type VersionCheck struct {
+	Name          string
+	ClusterLeader string
+}
+
+// ID returns a unique check identifier.
+func (vc *VersionCheck) ID() string {
+	return vc.Name
+}
+
+// Run is running
+func (vc *VersionCheck) Run(ctx context.Context, cfg *CLIConfigFlags) (string, int, error) {
+
+	// List of masters
+	var masterOpt URLFields
+	masterOpt.host = vc.ClusterLeader
+	masterOpt.port = mesosDNSPort
+	masterOpt.path = "/v1/hosts/master.mesos"
+
+	masterList, err := vc.ListOfMasters(cfg, masterOpt)
+	if err != nil {
+		return "", statusFailure, err
+	}
+
+	// List of agents
+	var agentOpt URLFields
+	agentOpt.host = vc.ClusterLeader
+	agentOpt.port = mesosMasterHTTPPort
+	agentOpt.path = "/slaves"
+
+	agentList, err := vc.ListOfAgents(cfg, agentOpt)
+	if err != nil {
+		return "", statusFailure, err
+	}
+
+	// Check version endpoint for each endpoint
+	var version map[string]bool
+	version = make(map[string]bool)
+	var versionURL URLFields
+	versionURL.path = "/dcos-metadata/dcos-version.json"
+	for _, master := range masterList {
+		versionURL.host = master
+		versionURL.port = 0
+		if cfg.ForceTLS {
+			versionURL.port = adminrouterMasterHTTPSPort
+		}
+		ver, err := vc.GetVersion(cfg, versionURL)
+		if err != nil {
+			return "", statusFailure, errors.Wrap(err, "Unable to get version")
+		}
+		version[ver] = true
+	}
+
+	for _, agent := range agentList {
+		versionURL.host = agent
+		versionURL.port = adminrouterAgentHTTPPort
+		if cfg.ForceTLS {
+			versionURL.port = adminrouterAgentHTTPSPort
+		}
+		ver, err := vc.GetVersion(cfg, versionURL)
+		if err != nil {
+			return "", statusFailure, errors.Wrap(err, "Unable to get version")
+		}
+		version[ver] = true
+	}
+
+	if len(version) <= 2 {
+		return "", statusOK, nil
+	}
+
+	if len(version) > 2 {
+		return "", statusWarning, errors.New("More than 2 dc/os versions on the cluster")
+	}
+
+	return "", statusUnknown, nil
+}
+
+// ListOfMasters returns the current list of masters in the cluster
+func (vc *VersionCheck) ListOfMasters(cfg *CLIConfigFlags, urlopt URLFields) ([]string, error) {
+	var masterResponse MasterListResponse
+	var masterIPs []string
+	response, err := vc.HTTPRequest(cfg, urlopt)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to fetch list of masters")
+	}
+
+	if err := json.Unmarshal(response, &masterResponse); err != nil {
+		return nil, errors.Wrap(err, "Unable to unmarshal response")
+	}
+
+	for _, addr := range masterResponse {
+		masterIPs = append(masterIPs, addr.IP)
+	}
+	return masterIPs, nil
+}
+
+// ListOfAgents returns the current list of agents in the cluster
+func (vc *VersionCheck) ListOfAgents(cfg *CLIConfigFlags, urlopt URLFields) ([]string, error) {
+	var agentResponse AgentListResponse
+	var agentIPs []string
+	response, err := vc.HTTPRequest(cfg, urlopt)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to fetch list of agents")
+	}
+
+	if err := json.Unmarshal(response, &agentResponse); err != nil {
+		return nil, errors.Wrap(err, "Unable to unmarshal response")
+	}
+
+	for _, hosts := range agentResponse.Slaves {
+		agentIPs = append(agentIPs, hosts.Hostname)
+	}
+	return agentIPs, nil
+}
+
+// GetVersion returns the dc/os version of a node
+func (vc *VersionCheck) GetVersion(cfg *CLIConfigFlags, urlopt URLFields) (string, error) {
+	var verResponse VersionResponse
+	response, err := vc.HTTPRequest(cfg, urlopt)
+	if err != nil {
+		return "", errors.Wrap(err, "Unable to get version")
+	}
+
+	if err := json.Unmarshal(response, &verResponse); err != nil {
+		return "", errors.Wrap(err, "Unable to marshal response")
+	}
+
+	return verResponse.Version, nil
+}
+
+// HTTPRequest verifies the results of the request
+func (vc *VersionCheck) HTTPRequest(cfg *CLIConfigFlags, urlOptions URLFields) ([]byte, error) {
+	httpClient, err := client.NewClient(cfg.IAMConfig, cfg.CACert)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create HTTP client")
+	}
+
+	url, err := vc.getURL(httpClient, cfg, urlOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("GET %s", url)
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create a new HTTP request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to execute GET %s", url)
+	}
+
+	//if err := json.NewDecoder(resp.Body).Decode(&jsonResponse); err != nil {
+	responseData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read response body")
+	}
+	defer resp.Body.Close()
+
+	return responseData, nil
+}
+
+func (vc *VersionCheck) getURL(httpClient *http.Client, cfg *CLIConfigFlags, urlOptions URLFields) (*url.URL, error) {
+	scheme := httpScheme
+	if cfg.ForceTLS {
+		scheme = httpsScheme
+	}
+
+	if urlOptions.port == 0 {
+		return &url.URL{
+			Scheme: scheme,
+			Host:   urlOptions.host,
+			Path:   urlOptions.path,
+		}, nil
+	}
+	return &url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(urlOptions.host, strconv.Itoa(urlOptions.port)),
+		Path:   urlOptions.path,
+	}, nil
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -9,11 +9,6 @@ import (
 )
 
 func TestVersionCheckUrl(t *testing.T) {
-	test := &VersionCheck{
-		Name:          "TEST",
-		ClusterLeader: "127.0.0.1",
-	}
-
 	for _, testCase := range []struct {
 		urlopt   URLFields
 		forceTLS bool
@@ -36,7 +31,7 @@ func TestVersionCheckUrl(t *testing.T) {
 			ForceTLS:  testCase.forceTLS,
 		}
 
-		url, err := test.getURL(nil, mockCLICfg, testCase.urlopt)
+		url, err := getURL(nil, mockCLICfg, testCase.urlopt)
 		if err != nil {
 			t.Fatalf("Error running getURL: %s", err)
 		}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestVersionCheckUrl(t *testing.T) {
+	test := &VersionCheck{
+		Name:          "TEST",
+		ClusterLeader: "127.0.0.1",
+	}
+
+	for _, testCase := range []struct {
+		urlopt   URLFields
+		forceTLS bool
+		expected string
+	}{
+		{
+			urlopt:   URLFields{"127.0.0.1", 5050, "metrics/snapshot"},
+			forceTLS: false,
+			expected: "http://127.0.0.1:5050/metrics/snapshot",
+		},
+		{
+			urlopt:   URLFields{"127.0.0.1", 0, "/v1/hosts/master.mesos"},
+			forceTLS: false,
+			expected: "http://127.0.0.1/v1/hosts/master.mesos",
+		},
+	} {
+		mockCLICfg := &CLIConfigFlags{
+			NodeIPStr: "127.0.0.1",
+			Role:      "master",
+			ForceTLS:  testCase.forceTLS,
+		}
+
+		url, err := test.getURL(nil, mockCLICfg, testCase.urlopt)
+		if err != nil {
+			t.Fatalf("Error running getURL: %s", err)
+		}
+
+		if url.String() != testCase.expected {
+			t.Fatalf("Expect %s. Got %s", testCase.expected, url)
+		}
+
+	}
+}
+
+// TestVersionCheckListofmasters gets list of masters from mesos-dns endpoint
+func TestVersionCheckListOfMasters(t *testing.T) {
+	for _, testCase := range []struct {
+		role      string
+		forceTLS  bool
+		status    int
+		response  string
+		expStatus int
+		expValue  string
+	}{
+		{
+			role:      "master",
+			forceTLS:  false,
+			status:    http.StatusOK,
+			response:  `[{ "host": "leader.mesos.", "ip": "10.0.4.197" }]`,
+			expStatus: statusOK,
+			expValue:  "10.0.4.197",
+		},
+	} {
+		mockCLICfg := &CLIConfigFlags{
+			NodeIPStr: "127.0.0.1",
+			Role:      testCase.role,
+			ForceTLS:  testCase.forceTLS,
+		}
+
+		masterHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(testCase.status)
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/v1/hosts/master.mesos" {
+				io.WriteString(w, testCase.response)
+			}
+		})
+
+		masterServer := httptest.NewServer(masterHandler)
+		defer masterServer.Close()
+
+		test := &VersionCheck{
+			Name:          "TEST",
+			ClusterLeader: "127.0.0.1",
+		}
+
+		testurl, err := url.Parse(masterServer.URL)
+		if err != nil {
+			t.Fatalf("could not parse")
+		}
+		var masterurlopt URLFields
+		masterurlopt.host = testurl.Host
+		masterurlopt.port = 0
+		masterurlopt.path = "/v1/hosts/master.mesos"
+
+		masters, err := test.ListOfMasters(mockCLICfg, masterurlopt)
+
+		if err != nil {
+			t.Fatalf("Status %s", err)
+		}
+		if masters[0] != testCase.expValue {
+			t.Fatalf("Getting random nonsense, not the correct value")
+		}
+	}
+}
+
+// TestVersionCheckListofAgents gets list of agents by parsing mesos endpoint /slaves
+func TestVersionCheckListOfAgents(t *testing.T) {
+	for _, testCase := range []struct {
+		role      string
+		forceTLS  bool
+		status    int
+		response  string
+		expStatus int
+		expValue  string
+		version   string
+	}{
+		{
+			role:      "master",
+			forceTLS:  false,
+			status:    http.StatusOK,
+			response:  `{"slaves":[{"id":"529c3971-b5bb-4f9e-b817-bb32def0ede2-S1","hostname":"10.0.6.233","port":5051,"attributes":{"public_ip":"true"},"pid":"slave(1)@10.0.6.233:5051","registered_time":1496728541.24296,"resources":{"disk":35566.0,"mem":14021.0,"gpus":0.0,"cpus":4.0,"ports":"[1-21, 23-5050, 5052-32000]"},"used_resources":{"disk":0.0,"mem":0.0,"gpus":0.0,"cpus":0.0},"offered_resources":{"disk":0.0,"mem":0.0,"gpus":0.0,"cpus":0.0},"reserved_resources":{"slave_public":{"disk":35566.0,"mem":14021.0,"gpus":0.0,"cpus":4.0,"ports":"[1-21, 23-5050, 5052-32000]"}},"unreserved_resources":{"disk":0.0,"mem":0.0,"gpus":0.0,"cpus":0.0},"active":true,"version":"1.3.0","capabilities":["MULTI_ROLE"],"reserved_resources_full":{"slave_public":[{"name":"ports","type":"RANGES","ranges":{"range":[{"begin":1,"end":21},{"begin":23,"end":5050},{"begin":5052,"end":32000}]},"role":"slave_public"},{"name":"disk","type":"SCALAR","scalar":{"value":35566.0},"role":"slave_public"},{"name":"cpus","type":"SCALAR","scalar":{"value":4.0},"role":"slave_public"},{"name":"mem","type":"SCALAR","scalar":{"value":14021.0},"role":"slave_public"}]},"used_resources_full":[],"offered_resources_full":[]}]}`,
+			expStatus: statusOK,
+			expValue:  "10.0.6.233",
+			version:   `{"version": "1.10-dev", "dcos-image-commit": "ccb53df0da261508249570df577c47bbbcc09f82", "bootstrap-id": "8468e43583e21ccb482ff303ed7496f84bbadb4d"}`,
+		},
+	} {
+		mockCLICfg := &CLIConfigFlags{
+			NodeIPStr: "127.0.0.1",
+			Role:      testCase.role,
+			ForceTLS:  testCase.forceTLS,
+		}
+
+		agentHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(testCase.status)
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/slaves" {
+				io.WriteString(w, testCase.response)
+			}
+			if r.URL.Path == "/dcos-metadata/dcos-version.json" {
+				io.WriteString(w, testCase.version)
+			}
+		})
+
+		agentServer := httptest.NewServer(agentHandler)
+		defer agentServer.Close()
+
+		test := &VersionCheck{
+			Name:          "TEST",
+			ClusterLeader: "127.0.0.1",
+		}
+
+		testurl, err := url.Parse(agentServer.URL)
+		if err != nil {
+			t.Fatalf("could not parse")
+		}
+		var agenturlopt URLFields
+		agenturlopt.host = testurl.Host
+		agenturlopt.port = 0
+		agenturlopt.path = "/slaves"
+
+		agents, err := test.ListOfAgents(mockCLICfg, agenturlopt)
+
+		if err != nil {
+			t.Fatalf("Status %s", err)
+		}
+		if agents[0] != testCase.expValue {
+			t.Fatalf("Getting random nonsense, not the correct value")
+		}
+
+		var versionurlopt URLFields
+		versionurlopt.host = testurl.Host
+		versionurlopt.port = 0
+		versionurlopt.path = "/dcos-metadata/dcos-version.json"
+
+		version, err := test.GetVersion(mockCLICfg, versionurlopt)
+
+		if err != nil {
+			t.Fatalf("Status %s", err)
+		}
+		if version != "1.10-dev" {
+			t.Fatalf("Getting nonsense %s, not the correct value", version)
+		}
+
+	}
+}


### PR DESCRIPTION
This cluster check verifies that no more than 2 versions of dc/os exist on a cluster. 

The code does the following steps:
1. Get a list of masters using the mesos-dns endpoint as described here - http://mesosphere.github.io/mesos-dns/docs/http.html 

2. Get a list of agents using the mesos endpoint http://mesos.apache.org/documentation/latest/endpoints/master/slaves/ 

3. Get version for each of the endpoints - https://dcos.io/docs/1.9/api/master-routes/ 

Make sure no more than 2 versions exist, the design decision was to return a warning and not failure if more than 2 versions exist. 

Apart from the actual cluster check this pr includes the following
1. Pull out constants to checks.go
2. Make a generic http request / get url function, this will get pulled out