### PR TITLE
Exclude checks systemd unit from the component check

### DIFF
--- a/cmd/checks/components/components_check_test.go
+++ b/cmd/checks/components/components_check_test.go
@@ -1,6 +1,8 @@
 package components
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/dcos/dcos-checks/common"
@@ -69,5 +71,19 @@ func TestComponentCheckGetHealthURL(t *testing.T) {
 		if url.String() != item.expected {
 			t.Fatalf("Expect %s. Got %s", item.expected, url.String())
 		}
+	}
+}
+
+func TestDiagnosticsResponse(t *testing.T) {
+	// A sample from the output of system/health/v1 with checks marked as not healthy
+	response := `{"units":[{"id":"dcos-adminrouter.service","health":0,"output":"","description":"exposes a unified control plane proxy for components and services using NGINX","help":"","name":"Admin Router Master"},{"id":"dcos-checks-poststart.service","health":1,"output":"","description":"Run node-poststart checks","help":"","name":"DC/OS Poststart Checks"},{"id":"dcos-checks-poststart.timer","health":1,"output":"","description":"timer for DC/OS Checks service","help":"","name":"DC/OS Checks Timer"},{"id":"dcos-cosmos.service","health":0,"output":"","description":"installs and manages DC/OS packages from DC/OS package repositories, such as the Mesosphere Universe","help":"","name":"DC/OS Package Manager (Cosmos)"},{"id":"dcos-diagnostics.service","health":0,"output":"","description":"aggregates and exposes component health","help":"","name":"DC/OS Diagnostics Master"},{"id":"dcos-diagnostics.socket","health":0,"output":"","description":"socket for DC/OS Diagnostics Agent","help":"","name":"DC/OS Diagnostics Agent Socket"}]}`
+
+	var dr diagnosticsResponse
+	if err := json.NewDecoder(strings.NewReader(response)).Decode(&dr); err != nil {
+		t.Fatalf("Error decoding")
+	}
+	_, retCode := dr.checkHealth()
+	if retCode != 0 {
+		t.Fatalf("Check health failed")
 	}
 }

--- a/cmd/checks/components/diagnostics_response.go
+++ b/cmd/checks/components/diagnostics_response.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dcos/dcos-checks/constants"
 )
@@ -20,7 +21,7 @@ type diagnosticsResponse struct {
 func (d *diagnosticsResponse) checkHealth() ([]string, int) {
 	var errorList []string
 	for _, unit := range d.Units {
-		if unit.Health != constants.StatusOK {
+		if (unit.Health != constants.StatusOK) && !(strings.Contains(unit.ID, "dcos-checks")) {
 			errorList = append(errorList, fmt.Sprintf("component %s has health status %d", unit.Name, unit.Health))
 		}
 	}


### PR DESCRIPTION
Failing checks because checks systemd unit failed to run does not make sense. Excluding checks from the component check.

Adding poststart as a systemd unit: https://github.com/dcos/dcos/pull/2069 