### PR TITLE
Use slice instead of array

### DIFF
--- a/cmd/checks/components/components_check.go
+++ b/cmd/checks/components/components_check.go
@@ -70,7 +70,7 @@ func Add(root *cobra.Command) {
 	componentsCmd.Flags().StringVarP(&healthURLPrefix, "health-url", "u", "/system/health/v1", "Set dcos-diagnostics health url")
 	componentsCmd.Flags().StringVarP(&scheme, "scheme", "s", "http", "Set dcos-diagnostics health url scheme")
 	componentsCmd.Flags().IntVarP(&port, "port", "p", 1050, "Set TCP port")
-	componentsCmd.Flags().StringArrayVarP(&excludeComponents, "exclude", "e", nil, "Exclude components from health check")
+	componentsCmd.Flags().StringSliceVarP(&excludeComponents, "exclude", "e", nil, "Exclude components from health check")
 }
 
 // Run invokes a systemd check and return error output, exit code and error.


### PR DESCRIPTION
Context: https://github.com/dcos/dcos/pull/2069 

StringArrayVarP defines a string flag with specified name, default value, and usage string. The argument p points to a []string variable in which to store the value of the flag. The value of each argument will not try to be separated by comma

^ this doesnt help what we are trying to do. Using slice instead. 
