### PR TITLE
Add constants for Marathon ports

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -28,6 +28,14 @@ const (
 	// listens for HTTPS requests
 	AdminrouterAgentHTTPSPort = 61002
 
+	// MarathonMasterHTTPPort is the port on which the Mesos master listens for
+	// HTTP requests.
+	MarathonMasterHTTPPort = 8080
+
+	// MarathonMasterHTTPPort is the port on which the Marathon master listens for
+	// HTTP requests.
+	MarathonMasterHTTPSPort = 8443
+
 	// MesosMasterHTTPPort is the port on which the Mesos master listens for
 	// HTTP requests.
 	MesosMasterHTTPPort = 5050

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -32,8 +32,8 @@ const (
 	// HTTP requests.
 	MarathonMasterHTTPPort = 8080
 
-	// MarathonMasterHTTPPort is the port on which the Marathon master listens for
-	// HTTP requests.
+	// MarathonMasterHTTPSPort is the port on which the Marathon master listens for
+	// HTTPS requests.
 	MarathonMasterHTTPSPort = 8443
 
 	// MesosMasterHTTPPort is the port on which the Mesos master listens for

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -28,7 +28,7 @@ const (
 	// listens for HTTPS requests
 	AdminrouterAgentHTTPSPort = 61002
 
-	// MarathonMasterHTTPPort is the port on which the Mesos master listens for
+	// MarathonMasterHTTPPort is the port on which the Marathon master listens for
 	// HTTP requests.
 	MarathonMasterHTTPPort = 8080
 


### PR DESCRIPTION
This PR adds the default HTTP/HTTPS ports for Marathon as constants. This allows for reliably querying the right Marathon endpoint in a dcos-check. The change is needed for an upcoming dcos-enterprise check that queries Marathon master instances for their leader opinion.