### PR TITLE
Bump dcos/dcos-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,8 +3,13 @@
 
 [[projects]]
   name = "github.com/dcos/dcos-go"
-  packages = ["dcos","dcos/http/transport","dcos/nodeutil","exec"]
-  revision = "0245b80f4b9e2cf772243f14628a5a80b3ff0311"
+  packages = [
+    "dcos",
+    "dcos/http/transport",
+    "dcos/nodeutil",
+    "exec"
+  ]
+  revision = "401ceabc567958049478a8f9cd5d94195a4bb25c"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
@@ -15,7 +20,18 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "f40e974e75af4e271d97ce0fc917af5898ae7bda"
 
 [[projects]]
@@ -56,7 +72,10 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
   version = "v1.0.2"
 
@@ -93,24 +112,43 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ed25519","ed25519/internal/edwards25519","ssh/terminal"]
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "ssh/terminal"
+  ]
   revision = "80db560fac1fb3e6ac81dbc7f8ae4c061f5257bd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "641605214e7dab930817f68e2fef560efbb033e5"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   name = "gopkg.in/square/go-jose.v2"
-  packages = [".","cipher","json","jwt"]
+  packages = [
+    ".",
+    "cipher",
+    "json",
+    "jwt"
+  ]
   revision = "6ee92191fea850cdcab9a18867abf5f521cdbadb"
   version = "v2.1.4"
 
@@ -123,6 +161,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bd8a92fb6877e7e33fe8ebebb81253afdfc810f7a7126fd1a9be1ab332b63266"
+  inputs-digest = "ed11c8567a383e460f15a3979383eb006b4ddb4eb8c912be0b56e4067e74d147"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/dcos/dcos-go"
-  revision = "0245b80f4b9e2cf772243f14628a5a80b3ff0311"
+  revision = "401ceabc567958049478a8f9cd5d94195a4bb25c"
 
 [[constraint]]
   name = "github.com/pkg/errors"

--- a/vendor/github.com/dcos/dcos-go/dcos/constants.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/constants.go
@@ -20,23 +20,8 @@ const (
 func GetFileDetectIPLocation() string {
 	switch runtime.GOOS {
 	case "windows":
-		return "/mesos/bin/detect_ip.ps1"
+		return "/opt/mesosphere/bin/detect_ip.ps1"
 	default:
 		return "/opt/mesosphere/bin/detect_ip"
 	}
 }
-
-// DC/OS DNS records.
-const (
-	// DNSRecordLeader is a domain name used by a leading master in DC/OS cluster.
-	DNSRecordLeader = "leader.mesos"
-)
-
-// DC/OS ports.
-const (
-	// PortMesosMaster defines a TCP port for mesos master.
-	PortMesosMaster = 5050
-
-	// PortMesosAgent defines a TCP port for mesos agent / public agent.
-	PortMesosAgent = 5051
-)

--- a/vendor/github.com/dcos/dcos-go/dcos/dns_records.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/dns_records.go
@@ -1,0 +1,13 @@
+package dcos
+
+// DC/OS DNS records.
+const (
+	// DNSRecordLeader is a domain name used by the leading Mesos master in a DC/OS cluster.
+	DNSRecordLeader = "leader.mesos"
+
+	// DNSRecordMarathonLeader is the domain name used by the leading Marathon master.
+	DNSRecordMarathonLeader = "marathon.mesos"
+
+	// DNSRecordMasters is the domain name listing the connected masters in a DC/OS cluster.
+	DNSRecordMasters = "master.mesos"
+)

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	defaultExecTimeout = 10 * time.Second
+	defaultExecTimeout       = 10 * time.Second
+	defaultClusterIDLocation = "/var/lib/dcos/cluster-id"
 )
 
 // ErrTaskNotFound is return if the canonical ID for a given task not found.
@@ -99,15 +100,6 @@ func getDefaultShellPath() string {
 	}
 }
 
-func getClusterIDLocation() string {
-	switch runtime.GOOS {
-	case "windows":
-		return "/mesos/var/lib/dcos/cluster-id"
-	default:
-		return "/var/lib/dcos/cluster-id"
-	}
-}
-
 // NewNodeInfo returns a new instance of NodeInfo implementation.
 func NewNodeInfo(client *http.Client, role string, options ...Option) (NodeInfo, error) {
 	if client == nil {
@@ -138,7 +130,7 @@ func NewNodeInfo(client *http.Client, role string, options ...Option) (NodeInfo,
 		detectIPTimeout:   defaultExecTimeout,
 		dnsRecordLeader:   dcos.DNSRecordLeader,
 		mesosStateURL:     defaultStateURL.String(),
-		clusterIDLocation: getClusterIDLocation(),
+		clusterIDLocation: defaultClusterIDLocation,
 	}
 
 	// update parameters with a caller input.

--- a/vendor/github.com/dcos/dcos-go/dcos/ports.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/ports.go
@@ -1,0 +1,28 @@
+package dcos
+
+// DC/OS ports.
+const (
+	// PortAdminrouterHTTP defines a TCP port for Adminrouter.
+	PortAdminrouterHTTP = 80
+
+	// PortExhibitor defines a TCP port for Exhibitor.
+	PortExhibitor = 8181
+
+	// PortHistoryService defines a TCP port for the DC/OS history service.
+	PortHistoryService = 15055
+
+	// PortMarathonHTTP defines a TCP port for Marathon.
+	PortMarathonHTTP = 8080
+
+	// PortMesosAgent defines a TCP port for Mesos on agent / public agent nodes.
+	PortMesosAgent = 5051
+
+	// PortMesosDNS defines a TCP port for MesosDNS.
+	PortMesosDNS = 8123
+
+	// PortMesosMaster defines a TCP port for Mesos on master nodes.
+	PortMesosMaster = 5050
+
+	// PortMetronomeHTTP defines a TCP port for Metronome.
+	PortMetronomeHTTP = 9090
+)


### PR DESCRIPTION
In order to incorporate the latest changes to dcos/dcos-go into mesosphere/dcos-checks-enterprise we must bump dcos-go here as it is also a dependency in dcos-checks-enterprise. Currently we cannot do much about how these things work, however when vgo becomes stable we should probably use a minimal version for dcos-go in both, dcos-checks and dcos-checks-enterprise.