### PR TITLE
Fix compilation on Darwin by updating noop stub

### DIFF
--- a/cmd/checks/time/time_darwin.go
+++ b/cmd/checks/time/time_darwin.go
@@ -17,7 +17,7 @@ package time
 
 import "github.com/spf13/cobra"
 
-// Add doesn't add this check on darwin b/c it's not supported
-func Add(root *cobra.Command) {
+// Register doesn't add this check on darwin b/c it's not supported
+func Register(root *cobra.Command) {
 	// does nothing on darwin
 }


### PR DESCRIPTION
The API of the subcommands was changed from `Add` to `Register` in 35e68e17 but the noop stub that enables compilation on Darwin platforms was not updated.

This change updates the API so that compilation (and thus test running, linting, etc.) works on Darwin again.