### PR TITLE
Switch jenkinsfile to pipeline syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         }
     }
     stages {
-        stage('testing') {
+        stage('test') {
             steps {
                 sh 'make test'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,25 +1,14 @@
-#!/usr/bin/env groovy
-
-def master_branches = ["master", ] as String[]
-
-if (master_branches.contains(env.BRANCH_NAME)) {
-    // Rebuild main branch once a day
-    properties([
-        pipelineTriggers([cron('H H * * *')])
-    ])
-}
-
-node('mesos-ubuntu') {
-    stage ('checkout-scm') {
-        dir("dcos-checks") {
-            checkout scm
+pipeline {
+    agent {
+        node {
+            label 'mesos-ubuntu'
         }
-        stash includes: 'dcos-checks/**', name: 'dcos-checks'
     }
-    stage ('run-tests') {
-		unstash 'dcos-checks'
-        dir("dcos-checks") {
-			sh 'make test'
+    stages {
+        stage('testing') {
+            steps {
+			    sh 'make test'
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     stages {
         stage('testing') {
             steps {
-			    sh 'make test'
+                sh 'make test'
             }
         }
     }


### PR DESCRIPTION
New unified Jenkins build. No more `-master` and `-pulls` builds. 

- [New Build](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fdcos-checks-new/activity)
- [Wiki page on Jenkins builds](https://wiki.mesosphere.com/display/ENG/Continuous+Delivery+and+Deployment+with+Jenkins)