### PR TITLE
fix ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.13
 
 ENV PATH /go/bin:$PATH
 ENV GOPATH /go


### PR DESCRIPTION
smartystreets/goconvey depends on smartystreets/assertions which in turn
only works with 1.13 starting from `v1.1.0`. so this is a try whether
everything still works with 1.13 to evade the need to pin old versions
of deps.